### PR TITLE
fix status format in results json; add logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM ubuntu:16.04
 MAINTAINER James Eddy <james.a.eddy@gmail.com>
 
 # set version here to minimize need for edits below
-ENV VERSION=1.0.0
+ENV VERSION=1.1.0
 
 # set up packages
 USER root

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -17,7 +17,7 @@ dct:creator:
 
 requirements:
 - class: DockerRequirement
-  dockerPull: quay.io/jaeddy/dockstore-tool-helloworld-checker:1.0.0
+  dockerPull: quay.io/jaeddy/dockstore-tool-helloworld-checker:1.1.0
 
 inputs:
   knowngood_file:

--- a/bin/helloworld_check
+++ b/bin/helloworld_check
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
+import logging
 import os
 import sys
 import json
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('helloworld_check')
+hdlr = logging.FileHandler('log.txt')
+formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr)
 
 def get_md5(file_path):
     """
     Collect md5 checksum for file and return as string.
     """
-    return os.popen("md5sum {}".format(file_path)).read().split()[0]
+    logger.info("getting MD5 checksum for file '{}'".format(file_path))
+    return os.popen("md5 {}".format(file_path)).read().split()[-1]
 
 def check_md5_equal(knowngood_path, helloworld_path):
     """
@@ -15,19 +24,23 @@ def check_md5_equal(knowngood_path, helloworld_path):
     """
     knownggood_md5 = get_md5(knowngood_path)
     helloworld_md5 = get_md5(helloworld_path)
-    return 'PASS' if knownggood_md5 == helloworld_md5 else 'FAIL'
+    logger.info("comparing two checksum values")
+    return knownggood_md5 == helloworld_md5
 
 def run_tests(knowngood_path, helloworld_path):
+    logger.info("running all tests...")
     check_steps = {'md5_check': check_md5_equal}
-    check_results = {'Steps': {}}
+    check_results = {'steps': {}}
     for step in check_steps:
-        check_results['Steps'][step] = check_steps[step](
+        logger.info("running test in step '{}'".format(step))
+        check_results['steps'][step] = check_steps[step](
             knowngood_path, helloworld_path
         )
-    if any([result == 'FAIL' for result in check_results['Steps'].values()]):
-        check_results['Overall'] = 'FAIL'
-    else:
-        check_results['Overall'] = 'PASS'
+        logger.info("passing status of step '{}' was '{}'"
+                    .format(step, check_results['steps'][step]))
+    check_results['overall'] = all(check_results['steps'].values())
+    logger.info("overall passing status was '{}'"
+                .format(check_results['overall']))
     return check_results
 
 
@@ -38,6 +51,7 @@ def main(argv):
     with open('results.json', 'w') as outfile:
         json.dump(run_tests(knowngood_path, helloworld_path), outfile,
                   indent=4)
+        logger.info("results saved to 'results.json'")
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/hello_world_checker.cwl.json
+++ b/hello_world_checker.cwl.json
@@ -1,0 +1,10 @@
+{
+    "knowngood_file": {
+        "class": "File",
+        "path": "knownoutput.txt"
+    },
+    "helloworld_file": {
+        "class": "File",
+        "path": "helloworld.txt"
+    }
+}

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,8 @@
+2017-05-24 20:27:11,267 helloworld_check INFO     running all tests...
+2017-05-24 20:27:11,267 helloworld_check INFO     running test in step 'md5_check'
+2017-05-24 20:27:11,267 helloworld_check INFO     getting MD5 checksum for file 'knownoutput.txt'
+2017-05-24 20:27:11,274 helloworld_check INFO     getting MD5 checksum for file 'helloworld.txt'
+2017-05-24 20:27:11,280 helloworld_check INFO     comparing two checksum values
+2017-05-24 20:27:11,280 helloworld_check INFO     passing status of step 'md5_check' was 'True'
+2017-05-24 20:27:11,280 helloworld_check INFO     overall passing status was 'True'
+2017-05-24 20:27:11,281 helloworld_check INFO     results saved to 'results.json'

--- a/results.json
+++ b/results.json
@@ -1,0 +1,6 @@
+{
+    "overall": true, 
+    "steps": {
+        "md5_check": true
+    }
+}


### PR DESCRIPTION
Previously reported PASS/FAIL instead of true/false in `results.json`; updated to match workflow on-boarding instructions for GA4GH-DREAM challenge. Also produces `log.txt` now.